### PR TITLE
ra: Skip test_change_revprop on macOS

### DIFF
--- a/src/ra.rs
+++ b/src/ra.rs
@@ -4366,6 +4366,11 @@ mod tests {
     }
 
     #[test]
+    // SVN's pre-revprop-change hook runner forks and execs a shell script,
+    // which is fork-unsafe on Darwin while the test harness runs many
+    // threads: the hook child is intermittently killed by a signal. There
+    // is nothing the binding can do about it, so skip this one on macOS.
+    #[cfg_attr(target_os = "macos", ignore)]
     fn test_change_revprop() {
         use std::fs;
         use std::io::Write;


### PR DESCRIPTION
SVN's pre-revprop-change hook runner forks and execs a shell script. That is fork-unsafe on Darwin while the test harness runs many threads, so the hook child is intermittently killed by a signal and the test fails in CI. The binding cannot influence how SVN spawns hooks, so skip this test on macOS rather than chase the flake.